### PR TITLE
support termination of errors by __close()

### DIFF
--- a/lapi.c
+++ b/lapi.c
@@ -197,7 +197,7 @@ LUA_API void lua_settop (lua_State *L, int idx) {
   newtop = L->top + diff;
   if (diff < 0 && L->tbclist >= newtop) {
     lua_assert(hastocloseCfunc(ci->nresults));
-    newtop = luaF_close(L, newtop, CLOSEKTOP, 0);
+    newtop = luaF_closewithouterr(L, newtop, CLOSEKTOP, 0);
   }
   L->top = newtop;  /* correct top only after closing any upvalue */
   lua_unlock(L);
@@ -210,7 +210,7 @@ LUA_API void lua_closeslot (lua_State *L, int idx) {
   level = index2stack(L, idx);
   api_check(L, hastocloseCfunc(L->ci->nresults) && L->tbclist == level,
      "no variable to close at given level");
-  level = luaF_close(L, level, CLOSEKTOP, 0);
+  level = luaF_closewithouterr(L, level, CLOSEKTOP, 0);
   setnilvalue(s2v(level));
   lua_unlock(L);
 }

--- a/ldo.c
+++ b/ldo.c
@@ -606,7 +606,7 @@ CallInfo *luaD_precall (lua_State *L, StkId func, int nresults) {
 ** check the stack before doing anything else. 'luaD_precall' already
 ** does that.
 */
-l_sinline void ccall (lua_State *L, StkId func, int nResults, int inc, int for_close) {
+l_sinline void ccall (lua_State *L, StkId func, int nResults, int inc, int ci_mask) {
   CallInfo *ci;
   L->nCcalls += inc;
   if (l_unlikely(getCcalls(L) >= LUAI_MAXCCALLS)) {
@@ -614,18 +614,18 @@ l_sinline void ccall (lua_State *L, StkId func, int nResults, int inc, int for_c
     luaE_checkcstack(L);
   }
   if ((ci = luaD_precall(L, func, nResults)) != NULL) {  /* Lua function? */
-    ci->callstatus = CIST_FRESH;  /* mark that it is a "fresh" execute */
-    if (for_close) {
-      ci->callstatus |= CIST_CLSRET;
-    }
+    ci->callstatus = CIST_FRESH | ci_mask;  /* mark that it is a "fresh" execute */
     luaV_execute(L, ci);  /* call it */
   }
   L->nCcalls -= inc;
 }
 
+/*
+** External raw interface for 'ccall'.  'yy' can be 1 to allow yielding.
+*/
 
-void luaD_rawcall (lua_State *L, StkId func, int nResults, int yy, int for_close) {
-  ccall(L, func, nResults, yy ? 1 : nyci, for_close);
+void luaD_rawcall (lua_State *L, StkId func, int nResults, int yy, int ci_mask) {
+  ccall(L, func, nResults, yy ? 1 : nyci, ci_mask);
 }
 
 

--- a/ldo.c
+++ b/ldo.c
@@ -432,7 +432,7 @@ l_sinline void moveresults (lua_State *L, StkId res, int nres, int wanted) {
       if (hastocloseCfunc(wanted)) {  /* to-be-closed variables? */
         L->ci->callstatus |= CIST_CLSRET;  /* in case of yields */
         L->ci->u2.nres = nres;
-        res = luaF_close(L, res, CLOSEKTOP, 1);
+        res = luaF_closewithouterr(L, res, CLOSEKTOP, 1);
         L->ci->callstatus &= ~CIST_CLSRET;
         if (L->hookmask) {  /* if needed, call hook after '__close's */
           ptrdiff_t savedres = savestack(L, res);
@@ -668,7 +668,7 @@ static int finishpcallk (lua_State *L,  CallInfo *ci) {
   else {  /* error */
     StkId func = restorestack(L, ci->u2.funcidx);
     L->allowhook = getoah(ci->callstatus);  /* restore 'allowhook' */
-    func = luaF_close(L, func, status, 1);  /* can yield or raise an error */
+    func = luaF_close(L, func, &status, 1);  /* can yield or raise an error */
     luaD_seterrorobj(L, status, func);
     luaD_shrinkstack(L);   /* restore stack size in case of overflow */
     setcistrecst(ci, LUA_OK);  /* clear original status */
@@ -902,7 +902,7 @@ struct CloseP {
 */
 static void closepaux (lua_State *L, void *ud) {
   struct CloseP *pcl = cast(struct CloseP *, ud);
-  luaF_close(L, pcl->level, pcl->status, 0);
+  luaF_close(L, pcl->level, &pcl->status, 0);
 }
 
 

--- a/ldo.h
+++ b/ldo.h
@@ -69,7 +69,7 @@ LUAI_FUNC int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
                                               int narg1, int delta);
 LUAI_FUNC CallInfo *luaD_precall (lua_State *L, StkId func, int nResults);
 LUAI_FUNC void luaD_call (lua_State *L, StkId func, int nResults);
-LUAI_FUNC void luaD_rawcall (lua_State *L, StkId func, int nResults, int yy, int for_close);
+LUAI_FUNC void luaD_rawcall (lua_State *L, StkId func, int nResults, int yy, int ci_mask);
 LUAI_FUNC void luaD_callnoyield (lua_State *L, StkId func, int nResults);
 LUAI_FUNC StkId luaD_tryfuncTM (lua_State *L, StkId func);
 LUAI_FUNC int luaD_closeprotected (lua_State *L, ptrdiff_t level, int status);

--- a/ldo.h
+++ b/ldo.h
@@ -69,6 +69,7 @@ LUAI_FUNC int luaD_pretailcall (lua_State *L, CallInfo *ci, StkId func,
                                               int narg1, int delta);
 LUAI_FUNC CallInfo *luaD_precall (lua_State *L, StkId func, int nResults);
 LUAI_FUNC void luaD_call (lua_State *L, StkId func, int nResults);
+LUAI_FUNC void luaD_rawcall (lua_State *L, StkId func, int nResults, int yy, int for_close);
 LUAI_FUNC void luaD_callnoyield (lua_State *L, StkId func, int nResults);
 LUAI_FUNC StkId luaD_tryfuncTM (lua_State *L, StkId func);
 LUAI_FUNC int luaD_closeprotected (lua_State *L, ptrdiff_t level, int status);

--- a/lfunc.c
+++ b/lfunc.c
@@ -104,15 +104,18 @@ UpVal *luaF_findupval (lua_State *L, StkId level) {
 ** Call closing method for object 'obj' with error message 'err'. The
 ** boolean 'yy' controls whether the call is yieldable.
 ** (This function assumes EXTRA_STACK.)
+** If called with an error, CIST_CLSRET is set so that the return
+** value will be captured into L->lasttbcterminated.
 */
 static void callclosemethod (lua_State *L, TValue *obj, TValue *err, int yy) {
   StkId top = L->top;
+  int ci_mask = ttisstrictnil(err) ? 0 : CIST_CLSRET;
   const TValue *tm = luaT_gettmbyobj(L, obj, TM_CLOSE);
   setobj2s(L, top, tm);  /* will call metamethod... */
   setobj2s(L, top + 1, obj);  /* with 'self' as the 1st argument */
   setobj2s(L, top + 2, err);  /* and error msg. as 2nd argument */
   L->top = top + 3;  /* add function and arguments */
-  luaD_rawcall(L, top, 0, yy, !ttisstrictnil(err));
+  luaD_rawcall(L, top, 0, yy, ci_mask);
 }
 
 

--- a/lfunc.c
+++ b/lfunc.c
@@ -105,7 +105,8 @@ UpVal *luaF_findupval (lua_State *L, StkId level) {
 ** boolean 'yy' controls whether the call is yieldable.
 ** (This function assumes EXTRA_STACK.)
 ** If called with an error, CIST_CLSRET is set so that the return
-** value will be captured into L->lasttbcterminated.
+** value will be captured into L->lasttbcterminated.  (It's done by 'poscall' /
+** 'OP_RETURN1', despite nResults of the call being set to 0.)
 */
 static void callclosemethod (lua_State *L, TValue *obj, TValue *err, int yy) {
   StkId top = L->top;
@@ -224,7 +225,8 @@ static void poptbclist (lua_State *L) {
 /*
 ** Close all upvalues and to-be-closed variables up to the given stack
 ** level. Return restored 'level'.  'status` may be modified to LUA_OK
-** if all errors were terminated.
+** if all errors were terminated.  (A __close method can terminate an
+** error by returing 'true'.)
 */
 StkId luaF_close (lua_State *L, StkId level, int *status, int yy) {
   ptrdiff_t levelrel = savestack(L, level);

--- a/lfunc.c
+++ b/lfunc.c
@@ -112,10 +112,7 @@ static void callclosemethod (lua_State *L, TValue *obj, TValue *err, int yy) {
   setobj2s(L, top + 1, obj);  /* with 'self' as the 1st argument */
   setobj2s(L, top + 2, err);  /* and error msg. as 2nd argument */
   L->top = top + 3;  /* add function and arguments */
-  if (yy)
-    luaD_call(L, top, 0);
-  else
-    luaD_callnoyield(L, top, 0);
+  luaD_rawcall(L, top, 0, yy, !ttisstrictnil(err));
 }
 
 
@@ -231,6 +228,7 @@ StkId luaF_close (lua_State *L, StkId level, int status, int yy) {
   while (L->tbclist >= level) {  /* traverse tbc's down to that level */
     StkId tbc = L->tbclist;  /* get variable index */
     poptbclist(L);  /* remove it from list */
+    L->lasttbcterminated = 0;
     prepcallclosemth(L, tbc, status, yy);  /* close variable */
     level = restorestack(L, levelrel);
   }

--- a/lfunc.h
+++ b/lfunc.h
@@ -54,7 +54,8 @@ LUAI_FUNC void luaF_initupvals (lua_State *L, LClosure *cl);
 LUAI_FUNC UpVal *luaF_findupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_newtbcupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_closeupval (lua_State *L, StkId level);
-LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int status, int yy);
+LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int *status, int yy);
+LUAI_FUNC StkId luaF_closewithouterr (lua_State *L, StkId level, int status, int yy);
 LUAI_FUNC void luaF_unlinkupval (UpVal *uv);
 LUAI_FUNC void luaF_freeproto (lua_State *L, Proto *f);
 LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,

--- a/lstate.c
+++ b/lstate.c
@@ -263,6 +263,7 @@ static void preinit_thread (lua_State *L, global_State *g) {
   L->status = LUA_OK;
   L->errfunc = 0;
   L->oldpc = 0;
+  L->lasttbcterminated = 0;
 }
 
 

--- a/lstate.h
+++ b/lstate.h
@@ -324,6 +324,7 @@ struct lua_State {
   int basehookcount;
   int hookcount;
   volatile l_signalT hookmask;
+  int lasttbcterminated;
 };
 
 

--- a/lstate.h
+++ b/lstate.h
@@ -324,7 +324,7 @@ struct lua_State {
   int basehookcount;
   int hookcount;
   volatile l_signalT hookmask;
-  int lasttbcterminated;
+  int lasttbcterminated;  /* 1 if most-recent __close call suppressed err */
 };
 
 

--- a/lvm.c
+++ b/lvm.c
@@ -1585,7 +1585,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_CLOSE) {
         StkId ra = RA(i);
-        Protect(luaF_close(L, ra, LUA_OK, 1));
+        Protect(luaF_closewithouterr(L, ra, LUA_OK, 1));
         vmbreak;
       }
       vmcase(OP_TBC) {
@@ -1722,7 +1722,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           ci->u2.nres = n;  /* save number of returns */
           if (L->top < ci->top)
             L->top = ci->top;
-          luaF_close(L, base, CLOSEKTOP, 1);
+          luaF_closewithouterr(L, base, CLOSEKTOP, 1);
           updatetrap(ci);
           updatestack(ci);
         }

--- a/lvm.c
+++ b/lvm.c
@@ -1762,7 +1762,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           int nres = ci->nresults;
           L->ci = ci->previous;  /* back to caller */
           if (nres == 0) {
-            if (l_unlikely(ci->callstatus & CIST_CLSRET))
+            if (l_unlikely(ci->callstatus & CIST_CLSRET))  /* force capture of close result? */
               L->lasttbcterminated = ttistrue(s2v(RA(i)));
             L->top = base - 1;  /* asked for no results */
           } else {

--- a/lvm.c
+++ b/lvm.c
@@ -1761,9 +1761,11 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
         else {  /* do the 'poscall' here */
           int nres = ci->nresults;
           L->ci = ci->previous;  /* back to caller */
-          if (nres == 0)
+          if (nres == 0) {
+            if (l_unlikely(ci->callstatus & CIST_CLSRET))
+              L->lasttbcterminated = ttistrue(s2v(RA(i)));
             L->top = base - 1;  /* asked for no results */
-          else {
+          } else {
             StkId ra = RA(i);
             setobjs2s(L, base - 1, ra);  /* at least this result */
             L->top = base;


### PR DESCRIPTION
If a `__close()` metamethod was called with an error in flight, the error can be terminated by returning `true`.

See [use cases](http://lua-users.org/lists/lua-l/2022-10/msg00041.html).

This is a work in progress, and the implementation may not be robust.

example (not yet working):
```lua
do
  local x <close> = setmetatable({}, {
    __close = function(self, err)
      print('__close()')
      return true
    end
  })

  error('oops')
  print('not reached')
end

print('goodbye')
```

```
__close()
goodbye
```

TODO:
  * [ ] fix stack unwind not stopping at the to-be-closed level
  * [ ] documentation
