### PR TITLE
`__close` error suppression

### DIFF
--- a/lapi.c
+++ b/lapi.c
@@ -199,7 +199,7 @@ LUA_API void lua_settop (lua_State *L, int idx) {
   newtop = L->top.p + diff;
   if (diff < 0 && L->tbclist.p >= newtop) {
     lua_assert(hastocloseCfunc(ci->nresults));
-    newtop = luaF_close(L, newtop, CLOSEKTOP, 0);
+    newtop = luaF_close(L, newtop, CLOSEKTOP, 0, NULL);
   }
   L->top.p = newtop;  /* correct top only after closing any upvalue */
   lua_unlock(L);
@@ -212,7 +212,7 @@ LUA_API void lua_closeslot (lua_State *L, int idx) {
   level = index2stack(L, idx);
   api_check(L, hastocloseCfunc(L->ci->nresults) && L->tbclist.p == level,
      "no variable to close at given level");
-  level = luaF_close(L, level, CLOSEKTOP, 0);
+  level = luaF_close(L, level, CLOSEKTOP, 0, NULL);
   setnilvalue(s2v(level));
   lua_unlock(L);
 }

--- a/lapi.c
+++ b/lapi.c
@@ -199,7 +199,7 @@ LUA_API void lua_settop (lua_State *L, int idx) {
   newtop = L->top.p + diff;
   if (diff < 0 && L->tbclist.p >= newtop) {
     lua_assert(hastocloseCfunc(ci->nresults));
-    newtop = luaF_close(L, newtop, CLOSEKTOP, 0, NULL);
+    newtop = luaF_closewithouterr(L, newtop, CLOSEKTOP, 0);
   }
   L->top.p = newtop;  /* correct top only after closing any upvalue */
   lua_unlock(L);
@@ -212,7 +212,7 @@ LUA_API void lua_closeslot (lua_State *L, int idx) {
   level = index2stack(L, idx);
   api_check(L, hastocloseCfunc(L->ci->nresults) && L->tbclist.p == level,
      "no variable to close at given level");
-  level = luaF_close(L, level, CLOSEKTOP, 0, NULL);
+  level = luaF_closewithouterr(L, level, CLOSEKTOP, 0);
   setnilvalue(s2v(level));
   lua_unlock(L);
 }

--- a/ldo.c
+++ b/ldo.c
@@ -458,7 +458,7 @@ l_sinline void moveresults (lua_State *L, StkId res, int nres, int wanted) {
       if (hastocloseCfunc(wanted)) {  /* to-be-closed variables? */
         L->ci->callstatus |= CIST_CLSRET;  /* in case of yields */
         L->ci->u2.nres = nres;
-        res = luaF_close(L, res, CLOSEKTOP, 1);
+        res = luaF_close(L, res, CLOSEKTOP, 1, NULL);
         L->ci->callstatus &= ~CIST_CLSRET;
         if (L->hookmask) {  /* if needed, call hook after '__close's */
           ptrdiff_t savedres = savestack(L, res);
@@ -686,10 +686,34 @@ static int finishpcallk (lua_State *L,  CallInfo *ci) {
   else {  /* error */
     StkId func = restorestack(L, ci->u2.funcidx);
     L->allowhook = getoah(ci->callstatus);  /* restore 'allowhook' */
-    func = luaF_close(L, func, status, 1);  /* can yield or raise an error */
+    if (ci->callstatus & CIST_CLSERR) {
+      /* re-entry: a __close yielded (and has now returned or errored) */
+      if (!(ci->callstatus & CIST_CLSSUP)) {
+        /* check the returned value for suppression */
+        if (ttistrue(s2v(L->top.p - 1))) {
+          ci->callstatus |= CIST_CLSSUP;
+          status = CLOSEKTOP;
+          setcistrecst(ci, LUA_OK);
+        }
+      }
+      L->top.p--;  /* remove __close result */
+      func = luaF_close(L, func, (ci->callstatus & CIST_CLSSUP)
+                                    ? CLOSEKTOP : status, 1, NULL);
+    }
+    else {
+      /* first entry: start closing tbc variables */
+      int newstatus;
+      ci->callstatus |= CIST_CLSERR;
+      func = luaF_close(L, func, status, 1, &newstatus);
+      if (newstatus == LUA_OK)
+        ci->callstatus |= CIST_CLSSUP;
+    }
+    if (ci->callstatus & CIST_CLSSUP)
+      status = LUA_OK;
     luaD_seterrorobj(L, status, func);
     luaD_shrinkstack(L);   /* restore stack size in case of overflow */
     setcistrecst(ci, LUA_OK);  /* clear original status */
+    ci->callstatus &= ~(CIST_CLSERR | CIST_CLSSUP);
   }
   ci->callstatus &= ~CIST_YPCALL;
   L->errfunc = ci->u.c.old_errfunc;
@@ -832,6 +856,7 @@ static int precover (lua_State *L, int status) {
   CallInfo *ci;
   while (errorstatus(status) && (ci = findpcall(L)) != NULL) {
     L->ci = ci;  /* go down to recovery functions */
+    ci->callstatus &= ~(CIST_CLSERR | CIST_CLSSUP);  /* error overrides */
     setcistrecst(ci, status);  /* status to finish 'pcall' */
     status = luaD_rawrunprotected(L, unroll, NULL);
   }
@@ -924,7 +949,9 @@ struct CloseP {
 */
 static void closepaux (lua_State *L, void *ud) {
   struct CloseP *pcl = cast(struct CloseP *, ud);
-  luaF_close(L, pcl->level, pcl->status, 0);
+  int newstatus = pcl->status;
+  luaF_close(L, pcl->level, pcl->status, 0, &newstatus);
+  pcl->status = newstatus;
 }
 
 

--- a/ldo.c
+++ b/ldo.c
@@ -10,7 +10,6 @@
 #include "lprefix.h"
 
 
-#include <setjmp.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -43,49 +42,6 @@
 ** Error-recovery functions
 ** =======================================================
 */
-
-/*
-** LUAI_THROW/LUAI_TRY define how Lua does exception handling. By
-** default, Lua handles errors with exceptions when compiling as
-** C++ code, with _longjmp/_setjmp when asked to use them, and with
-** longjmp/setjmp otherwise.
-*/
-#if !defined(LUAI_THROW)				/* { */
-
-#if defined(__cplusplus) && !defined(LUA_USE_LONGJMP)	/* { */
-
-/* C++ exceptions */
-#define LUAI_THROW(L,c)		throw(c)
-#define LUAI_TRY(L,c,a) \
-	try { a } catch(...) { if ((c)->status == 0) (c)->status = -1; }
-#define luai_jmpbuf		int  /* dummy variable */
-
-#elif defined(LUA_USE_POSIX)				/* }{ */
-
-/* in POSIX, try _longjmp/_setjmp (more efficient) */
-#define LUAI_THROW(L,c)		_longjmp((c)->b, 1)
-#define LUAI_TRY(L,c,a)		if (_setjmp((c)->b) == 0) { a }
-#define luai_jmpbuf		jmp_buf
-
-#else							/* }{ */
-
-/* ISO C handling with long jumps */
-#define LUAI_THROW(L,c)		longjmp((c)->b, 1)
-#define LUAI_TRY(L,c,a)		if (setjmp((c)->b) == 0) { a }
-#define luai_jmpbuf		jmp_buf
-
-#endif							/* } */
-
-#endif							/* } */
-
-
-
-/* chain list of long jump buffers */
-struct lua_longjmp {
-  struct lua_longjmp *previous;
-  luai_jmpbuf b;
-  volatile int status;  /* error code */
-};
 
 
 void luaD_seterrorobj (lua_State *L, int errcode, StkId oldtop) {

--- a/ldo.c
+++ b/ldo.c
@@ -458,7 +458,7 @@ l_sinline void moveresults (lua_State *L, StkId res, int nres, int wanted) {
       if (hastocloseCfunc(wanted)) {  /* to-be-closed variables? */
         L->ci->callstatus |= CIST_CLSRET;  /* in case of yields */
         L->ci->u2.nres = nres;
-        res = luaF_close(L, res, CLOSEKTOP, 1, NULL);
+        res = luaF_closewithouterr(L, res, CLOSEKTOP, 1);
         L->ci->callstatus &= ~CIST_CLSRET;
         if (L->hookmask) {  /* if needed, call hook after '__close's */
           ptrdiff_t savedres = savestack(L, res);
@@ -732,16 +732,20 @@ static int finishpcallk (lua_State *L,  CallInfo *ci) {
         }
       }
       L->top.p--;  /* remove __close result */
-      func = luaF_close(L, func, (ci->callstatus & CIST_CLSSUP)
-                                    ? CLOSEKTOP : status, 1, NULL);
+      {
+        int closestatus = (ci->callstatus & CIST_CLSSUP)
+                            ? CLOSEKTOP : status;
+        func = luaF_close(L, func, &closestatus, 1);
+        if (closestatus == LUA_OK)
+          ci->callstatus |= CIST_CLSSUP;
+      }
     }
     else {
       /* first entry: start closing tbc variables */
-      int newstatus;
       saveretvals(L);  /* save return values before close overwrites them */
       ci->callstatus |= CIST_CLSERR;
-      func = luaF_close(L, func, status, 1, &newstatus);
-      if (newstatus == LUA_OK)
+      func = luaF_close(L, func, &status, 1);
+      if (status == LUA_OK)
         ci->callstatus |= CIST_CLSSUP;
     }
     if (ci->callstatus & CIST_CLSSUP && L->retbuf != NULL) {
@@ -998,9 +1002,7 @@ struct CloseP {
 */
 static void closepaux (lua_State *L, void *ud) {
   struct CloseP *pcl = cast(struct CloseP *, ud);
-  int newstatus = pcl->status;
-  luaF_close(L, pcl->level, pcl->status, 0, &newstatus);
-  pcl->status = newstatus;
+  luaF_close(L, pcl->level, &pcl->status, 0);
 }
 
 

--- a/ldo.c
+++ b/ldo.c
@@ -664,6 +664,41 @@ void luaD_callnoyield (lua_State *L, StkId func, int nResults) {
 
 
 /*
+** Save pending return values to a heap buffer before __close methods
+** overwrite the stack.  Uses 'luaM_realloc_' (which returns NULL on
+** failure instead of throwing) so that OOM during error recovery does
+** not raise a second error; the caller falls back to 'luaD_seterrorobj'.
+*/
+static void saveretvals (lua_State *L) {
+  if (L->savedret != 0 && L->retbuf == NULL) {
+    int nret = L->nsavedret;
+    if (nret > 0) {
+      StkId ra = restorestack(L, L->savedret);
+      TValue *buf = cast(TValue *,
+          luaM_realloc_(L, NULL, 0, nret * sizeof(TValue)));
+      if (buf != NULL) {
+        int i;
+        for (i = 0; i < nret; i++)
+          buf[i] = *s2v(ra + i);
+        L->retbuf = buf;
+        L->nretbuf = nret;
+      }
+    }
+    L->savedret = 0;
+  }
+}
+
+
+static void freeretbuf (lua_State *L) {
+  if (L->retbuf != NULL) {
+    luaM_free_(L, L->retbuf, L->nretbuf * sizeof(TValue));
+    L->retbuf = NULL;
+    L->nretbuf = 0;
+  }
+}
+
+
+/*
 ** Finish the job of 'lua_pcallk' after it was interrupted by an yield.
 ** (The caller, 'finishCcall', does the final call to 'adjustresults'.)
 ** The main job is to complete the 'luaD_pcall' called by 'lua_pcallk'.
@@ -703,14 +738,27 @@ static int finishpcallk (lua_State *L,  CallInfo *ci) {
     else {
       /* first entry: start closing tbc variables */
       int newstatus;
+      saveretvals(L);  /* save return values before close overwrites them */
       ci->callstatus |= CIST_CLSERR;
       func = luaF_close(L, func, status, 1, &newstatus);
       if (newstatus == LUA_OK)
         ci->callstatus |= CIST_CLSSUP;
     }
-    if (ci->callstatus & CIST_CLSSUP)
+    if (ci->callstatus & CIST_CLSSUP && L->retbuf != NULL) {
+      /* suppressed with saved return values: restore them */
+      int i;
+      for (i = 0; i < L->nretbuf; i++)
+        setobj2s(L, func + i, &L->retbuf[i]);
+      L->top.p = func + L->nretbuf;
+      freeretbuf(L);
       status = LUA_OK;
-    luaD_seterrorobj(L, status, func);
+    }
+    else {
+      if (ci->callstatus & CIST_CLSSUP)
+        status = LUA_OK;
+      luaD_seterrorobj(L, status, func);
+      freeretbuf(L);
+    }
     luaD_shrinkstack(L);   /* restore stack size in case of overflow */
     setcistrecst(ci, LUA_OK);  /* clear original status */
     ci->callstatus &= ~(CIST_CLSERR | CIST_CLSSUP);
@@ -741,6 +789,7 @@ static void finishCcall (lua_State *L, CallInfo *ci) {
   if (ci->callstatus & CIST_CLSRET) {  /* was returning? */
     lua_assert(hastocloseCfunc(ci->nresults));
     n = ci->u2.nres;  /* just redo 'luaD_poscall' */
+    L->top.p--;  /* remove __close result left on the stack */
     /* don't need to reset CIST_CLSRET, as it will be set again anyway */
   }
   else {
@@ -987,16 +1036,33 @@ int luaD_pcall (lua_State *L, Pfunc func, void *u,
   CallInfo *old_ci = L->ci;
   lu_byte old_allowhooks = L->allowhook;
   ptrdiff_t old_errfunc = L->errfunc;
+  ptrdiff_t old_savedret = L->savedret;
+  int old_nsavedret = L->nsavedret;
   L->errfunc = ef;
   status = luaD_rawrunprotected(L, func, u);
   if (l_unlikely(status != LUA_OK)) {  /* an error occurred? */
     L->ci = old_ci;
     L->allowhook = old_allowhooks;
+    saveretvals(L);  /* save return values before closeprotected */
     status = luaD_closeprotected(L, old_top, status);
-    luaD_seterrorobj(L, status, restorestack(L, old_top));
+    if (status == LUA_OK && L->retbuf != NULL) {
+      /* error was suppressed and we have saved return values */
+      StkId dest = restorestack(L, old_top);
+      int i;
+      for (i = 0; i < L->nretbuf; i++)
+        setobj2s(L, dest + i, &L->retbuf[i]);
+      L->top.p = dest + L->nretbuf;
+      freeretbuf(L);
+    }
+    else {
+      luaD_seterrorobj(L, status, restorestack(L, old_top));
+      freeretbuf(L);
+    }
     luaD_shrinkstack(L);   /* restore stack size in case of overflow */
   }
   L->errfunc = old_errfunc;
+  L->savedret = old_savedret;
+  L->nsavedret = old_nsavedret;
   return status;
 }
 

--- a/ldo.h
+++ b/ldo.h
@@ -8,10 +8,57 @@
 #define ldo_h
 
 
+#include <setjmp.h>
+
 #include "llimits.h"
 #include "lobject.h"
 #include "lstate.h"
 #include "lzio.h"
+
+
+/*
+** LUAI_THROW/LUAI_TRY define how Lua does exception handling. By
+** default, Lua handles errors with exceptions when compiling as
+** C++ code, with _longjmp/_setjmp when asked to use them, and with
+** longjmp/setjmp otherwise.
+*/
+#if !defined(LUAI_THROW)				/* { */
+
+#if defined(__cplusplus) && !defined(LUA_USE_LONGJMP)	/* { */
+
+/* C++ exceptions */
+#define LUAI_THROW(L,c)		throw(c)
+#define LUAI_TRY(L,c,a) \
+	try { a } catch(...) { if ((c)->status == 0) (c)->status = -1; }
+#define luai_jmpbuf		int  /* dummy variable */
+
+#elif defined(LUA_USE_POSIX)				/* }{ */
+
+/* in POSIX, try _longjmp/_setjmp (more efficient) */
+#define LUAI_THROW(L,c)		_longjmp((c)->b, 1)
+#define LUAI_TRY(L,c,a)		if (_setjmp((c)->b) == 0) { a }
+#define luai_jmpbuf		jmp_buf
+#define luai_setjmp(buf)	_setjmp(buf)
+
+#else							/* }{ */
+
+/* ISO C handling with long jumps */
+#define LUAI_THROW(L,c)		longjmp((c)->b, 1)
+#define LUAI_TRY(L,c,a)		if (setjmp((c)->b) == 0) { a }
+#define luai_jmpbuf		jmp_buf
+#define luai_setjmp(buf)	setjmp(buf)
+
+#endif							/* } */
+
+#endif							/* } */
+
+
+/* chain list of long jump buffers */
+struct lua_longjmp {
+  struct lua_longjmp *previous;
+  luai_jmpbuf b;
+  volatile int status;  /* error code */
+};
 
 
 /*

--- a/ldump.c
+++ b/ldump.c
@@ -190,6 +190,7 @@ static void dumpFunction (DumpState *D, const Proto *f, TString *psource) {
   dumpByte(D, f->numparams);
   dumpByte(D, f->is_vararg);
   dumpByte(D, f->maxstacksize);
+  dumpByte(D, f->needclose);
   dumpCode(D, f);
   dumpConstants(D, f);
   dumpUpvalues(D, f);

--- a/ldump.c
+++ b/ldump.c
@@ -190,7 +190,6 @@ static void dumpFunction (DumpState *D, const Proto *f, TString *psource) {
   dumpByte(D, f->numparams);
   dumpByte(D, f->is_vararg);
   dumpByte(D, f->maxstacksize);
-  dumpByte(D, f->needclose);
   dumpCode(D, f);
   dumpConstants(D, f);
   dumpUpvalues(D, f);

--- a/lfunc.c
+++ b/lfunc.c
@@ -20,6 +20,7 @@
 #include "lgc.h"
 #include "lmem.h"
 #include "lobject.h"
+#include "lopcodes.h"
 #include "lstate.h"
 
 
@@ -289,6 +290,19 @@ Proto *luaF_newproto (lua_State *L) {
   f->lastlinedefined = 0;
   f->source = NULL;
   return f;
+}
+
+
+void luaF_setneedclose (Proto *f) {
+  int hastbc = 0, hasclose = 0;
+  int i;
+  for (i = 0; i < f->sizecode; i++) {
+    OpCode op = GET_OPCODE(f->code[i]);
+    if (op == OP_TBC || op == OP_TFORPREP) hastbc = 1;
+    else if (op == OP_CLOSE) hasclose = 1;
+    if (hastbc && hasclose) break;
+  }
+  f->needclose = cast_byte(hastbc && hasclose);
 }
 
 

--- a/lfunc.c
+++ b/lfunc.c
@@ -282,6 +282,7 @@ Proto *luaF_newproto (lua_State *L) {
   f->numparams = 0;
   f->is_vararg = 0;
   f->maxstacksize = 0;
+  f->needclose = 0;
   f->locvars = NULL;
   f->sizelocvars = 0;
   f->linedefined = 0;

--- a/lfunc.c
+++ b/lfunc.c
@@ -23,6 +23,9 @@
 #include "lstate.h"
 
 
+#define errorstatus(s)	((s) > LUA_YIELD)
+
+
 
 CClosure *luaF_newCclosure (lua_State *L, int nupvals) {
   GCObject *o = luaC_newobj(L, LUA_VCCL, sizeCclosure(nupvals));
@@ -104,17 +107,24 @@ UpVal *luaF_findupval (lua_State *L, StkId level) {
 ** boolean 'yy' controls whether the call is yieldable.
 ** (This function assumes EXTRA_STACK.)
 */
-static void callclosemethod (lua_State *L, TValue *obj, TValue *err, int yy) {
+static int callclosemethod (lua_State *L, TValue *obj, TValue *err, int yy) {
   StkId top = L->top.p;
+  ptrdiff_t toprel = savestack(L, top);
   const TValue *tm = luaT_gettmbyobj(L, obj, TM_CLOSE);
   setobj2s(L, top, tm);  /* will call metamethod... */
   setobj2s(L, top + 1, obj);  /* with 'self' as the 1st argument */
   setobj2s(L, top + 2, err);  /* and error msg. as 2nd argument */
   L->top.p = top + 3;  /* add function and arguments */
   if (yy)
-    luaD_call(L, top, 0);
+    luaD_call(L, top, 1);
   else
-    luaD_callnoyield(L, top, 0);
+    luaD_callnoyield(L, top, 1);
+  top = restorestack(L, toprel);  /* stack may have been reallocated */
+  {
+    int suppressed = ttistrue(s2v(top));
+    L->top.p = top;  /* remove result */
+    return suppressed;
+  }
 }
 
 
@@ -140,7 +150,7 @@ static void checkclosemth (lua_State *L, StkId level) {
 ** the 'level' of the upvalue being closed, as everything after that
 ** won't be used again.
 */
-static void prepcallclosemth (lua_State *L, StkId level, int status, int yy) {
+static int prepcallclosemth (lua_State *L, StkId level, int status, int yy) {
   TValue *uv = s2v(level);  /* value being closed */
   TValue *errobj;
   if (status == CLOSEKTOP)
@@ -149,7 +159,7 @@ static void prepcallclosemth (lua_State *L, StkId level, int status, int yy) {
     errobj = s2v(level + 1);  /* error object goes after 'uv' */
     luaD_seterrorobj(L, status, level + 1);  /* set error object */
   }
-  callclosemethod(L, uv, errobj, yy);
+  return callclosemethod(L, uv, errobj, yy);
 }
 
 
@@ -224,15 +234,22 @@ static void poptbclist (lua_State *L) {
 ** Close all upvalues and to-be-closed variables up to the given stack
 ** level. Return restored 'level'.
 */
-StkId luaF_close (lua_State *L, StkId level, int status, int yy) {
+StkId luaF_close (lua_State *L, StkId level, int status, int yy,
+                  int *pstatus) {
   ptrdiff_t levelrel = savestack(L, level);
+  int suppressed = 0;
   luaF_closeupval(L, level);  /* first, close the upvalues */
   while (L->tbclist.p >= level) {  /* traverse tbc's down to that level */
     StkId tbc = L->tbclist.p;  /* get variable index */
     poptbclist(L);  /* remove it from list */
-    prepcallclosemth(L, tbc, status, yy);  /* close variable */
+    if (prepcallclosemth(L, tbc, status, yy) && errorstatus(status)) {
+      suppressed = 1;
+      status = CLOSEKTOP;  /* subsequent __close calls see nil error */
+    }
     level = restorestack(L, levelrel);
   }
+  if (pstatus != NULL)
+    *pstatus = suppressed ? LUA_OK : status;
   return level;
 }
 

--- a/lfunc.c
+++ b/lfunc.c
@@ -232,25 +232,35 @@ static void poptbclist (lua_State *L) {
 
 /*
 ** Close all upvalues and to-be-closed variables up to the given stack
-** level. Return restored 'level'.
+** level. Return restored 'level'.  '*status' may be changed to LUA_OK
+** if all errors were suppressed by '__close' methods returning true.
 */
-StkId luaF_close (lua_State *L, StkId level, int status, int yy,
-                  int *pstatus) {
+StkId luaF_close (lua_State *L, StkId level, int *status, int yy) {
   ptrdiff_t levelrel = savestack(L, level);
   int suppressed = 0;
   luaF_closeupval(L, level);  /* first, close the upvalues */
   while (L->tbclist.p >= level) {  /* traverse tbc's down to that level */
     StkId tbc = L->tbclist.p;  /* get variable index */
     poptbclist(L);  /* remove it from list */
-    if (prepcallclosemth(L, tbc, status, yy) && errorstatus(status)) {
+    if (prepcallclosemth(L, tbc, *status, yy) && errorstatus(*status)) {
       suppressed = 1;
-      status = CLOSEKTOP;  /* subsequent __close calls see nil error */
+      *status = CLOSEKTOP;  /* subsequent __close calls see nil error */
     }
     level = restorestack(L, levelrel);
   }
-  if (pstatus != NULL)
-    *pstatus = suppressed ? LUA_OK : status;
+  if (suppressed)
+    *status = LUA_OK;
   return level;
+}
+
+
+/*
+** Close upvalues and tbc variables with a non-error status
+** (suppression not applicable).
+*/
+StkId luaF_closewithouterr (lua_State *L, StkId level, int status, int yy) {
+  lua_assert(!errorstatus(status));
+  return luaF_close(L, level, &status, yy);
 }
 
 

--- a/lfunc.h
+++ b/lfunc.h
@@ -58,6 +58,7 @@ LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int *status, int yy);
 LUAI_FUNC StkId luaF_closewithouterr (lua_State *L, StkId level, int status,
                                       int yy);
 LUAI_FUNC void luaF_unlinkupval (UpVal *uv);
+LUAI_FUNC void luaF_setneedclose (Proto *f);
 LUAI_FUNC void luaF_freeproto (lua_State *L, Proto *f);
 LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,
                                          int pc);

--- a/lfunc.h
+++ b/lfunc.h
@@ -54,7 +54,8 @@ LUAI_FUNC void luaF_initupvals (lua_State *L, LClosure *cl);
 LUAI_FUNC UpVal *luaF_findupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_newtbcupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_closeupval (lua_State *L, StkId level);
-LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int status, int yy);
+LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int status, int yy,
+                            int *pstatus);
 LUAI_FUNC void luaF_unlinkupval (UpVal *uv);
 LUAI_FUNC void luaF_freeproto (lua_State *L, Proto *f);
 LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,

--- a/lfunc.h
+++ b/lfunc.h
@@ -54,8 +54,9 @@ LUAI_FUNC void luaF_initupvals (lua_State *L, LClosure *cl);
 LUAI_FUNC UpVal *luaF_findupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_newtbcupval (lua_State *L, StkId level);
 LUAI_FUNC void luaF_closeupval (lua_State *L, StkId level);
-LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int status, int yy,
-                            int *pstatus);
+LUAI_FUNC StkId luaF_close (lua_State *L, StkId level, int *status, int yy);
+LUAI_FUNC StkId luaF_closewithouterr (lua_State *L, StkId level, int status,
+                                      int yy);
 LUAI_FUNC void luaF_unlinkupval (UpVal *uv);
 LUAI_FUNC void luaF_freeproto (lua_State *L, Proto *f);
 LUAI_FUNC const char *luaF_getlocalname (const Proto *func, int local_number,

--- a/lgc.c
+++ b/lgc.c
@@ -637,6 +637,11 @@ static int traversethread (global_State *g, lua_State *th) {
              th->openupval == NULL || isintwups(th));
   for (; o < th->top.p; o++)  /* mark live elements in the stack */
     markvalue(g, s2v(o));
+  if (th->retbuf != NULL) {  /* saved return values for suppression? */
+    int i;
+    for (i = 0; i < th->nretbuf; i++)
+      markvalue(g, &th->retbuf[i]);
+  }
   for (uv = th->openupval; uv != NULL; uv = uv->u.open.next)
     markobject(g, uv);  /* open upvalues cannot be collected */
   if (g->gcstate == GCSatomic) {  /* final traversal? */

--- a/lobject.h
+++ b/lobject.h
@@ -552,6 +552,7 @@ typedef struct Proto {
   lu_byte numparams;  /* number of fixed (named) parameters */
   lu_byte is_vararg;
   lu_byte maxstacksize;  /* number of registers needed by this function */
+  lu_byte needclose;  /* function has to-be-closed variables */
   int sizeupvalues;  /* size of 'upvalues' */
   int sizek;  /* size of 'k' */
   int sizecode;

--- a/lparser.c
+++ b/lparser.c
@@ -761,6 +761,17 @@ static void close_func (LexState *ls) {
   leaveblock(fs);
   lua_assert(fs->bl == NULL);
   luaK_finish(fs);
+  {
+    int hastbc = 0, hasclose = 0;
+    int i;
+    for (i = 0; i < fs->pc; i++) {
+      OpCode op = GET_OPCODE(f->code[i]);
+      if (op == OP_TBC || op == OP_TFORPREP) hastbc = 1;
+      else if (op == OP_CLOSE) hasclose = 1;
+      if (hastbc && hasclose) break;
+    }
+    f->needclose = cast_byte(hastbc && hasclose);
+  }
   luaM_shrinkvector(L, f->code, f->sizecode, fs->pc, Instruction);
   luaM_shrinkvector(L, f->lineinfo, f->sizelineinfo, fs->pc, ls_byte);
   luaM_shrinkvector(L, f->abslineinfo, f->sizeabslineinfo,

--- a/lparser.c
+++ b/lparser.c
@@ -761,18 +761,8 @@ static void close_func (LexState *ls) {
   leaveblock(fs);
   lua_assert(fs->bl == NULL);
   luaK_finish(fs);
-  {
-    int hastbc = 0, hasclose = 0;
-    int i;
-    for (i = 0; i < fs->pc; i++) {
-      OpCode op = GET_OPCODE(f->code[i]);
-      if (op == OP_TBC || op == OP_TFORPREP) hastbc = 1;
-      else if (op == OP_CLOSE) hasclose = 1;
-      if (hastbc && hasclose) break;
-    }
-    f->needclose = cast_byte(hastbc && hasclose);
-  }
   luaM_shrinkvector(L, f->code, f->sizecode, fs->pc, Instruction);
+  luaF_setneedclose(f);
   luaM_shrinkvector(L, f->lineinfo, f->sizelineinfo, fs->pc, ls_byte);
   luaM_shrinkvector(L, f->abslineinfo, f->sizeabslineinfo,
                        fs->nabslineinfo, AbsLineInfo);

--- a/lstate.c
+++ b/lstate.c
@@ -263,6 +263,10 @@ static void preinit_thread (lua_State *L, global_State *g) {
   L->status = LUA_OK;
   L->errfunc = 0;
   L->oldpc = 0;
+  L->retbuf = NULL;
+  L->savedret = 0;
+  L->nsavedret = 0;
+  L->nretbuf = 0;
 }
 
 
@@ -278,6 +282,8 @@ static void close_state (lua_State *L) {
     luaC_freeallobjects(L);  /* collect all objects */
     luai_userstateclose(L);
   }
+  if (L->retbuf != NULL)
+    luaM_freearray(L, L->retbuf, L->nretbuf);
   luaM_freearray(L, G(L)->strt.hash, G(L)->strt.size);
   freestack(L);
   lua_assert(gettotalbytes(g) == sizeof(LG));
@@ -316,6 +322,8 @@ void luaE_freethread (lua_State *L, lua_State *L1) {
   LX *l = fromstate(L1);
   luaF_closeupval(L1, L1->stack.p);  /* close all upvalues */
   lua_assert(L1->openupval == NULL);
+  if (L1->retbuf != NULL)
+    luaM_freearray(L, L1->retbuf, L1->nretbuf);
   luai_userstatefree(L, L1);
   freestack(L1);
   luaM_free(L, l);

--- a/lstate.h
+++ b/lstate.h
@@ -222,8 +222,8 @@ struct CallInfo {
 #if defined(LUA_COMPAT_LT_LE)
 #define CIST_LEQ	(1<<13)  /* using __lt for __le */
 #endif
-#define CIST_CLSERR	(1<<14)  /* closing tbc vars for error recovery */
-#define CIST_CLSSUP	(1<<15)  /* error suppressed by __close, still closing */
+#define CIST_CLSERR	(1<<14)  /* error recovery: closing tbc vars (pcall or block) */
+#define CIST_CLSSUP	(1<<15)  /* error recovery: suppressed by __close */
 
 
 /*

--- a/lstate.h
+++ b/lstate.h
@@ -331,6 +331,10 @@ struct lua_State {
   int basehookcount;
   int hookcount;
   volatile l_signalT hookmask;
+  TValue *retbuf;  /* saved return values for suppression recovery */
+  ptrdiff_t savedret;  /* stack offset of return values during OP_RETURN close */
+  int nsavedret;  /* count of return values at savedret */
+  int nretbuf;  /* count of values in retbuf */
 };
 
 

--- a/lstate.h
+++ b/lstate.h
@@ -222,6 +222,8 @@ struct CallInfo {
 #if defined(LUA_COMPAT_LT_LE)
 #define CIST_LEQ	(1<<13)  /* using __lt for __le */
 #endif
+#define CIST_CLSERR	(1<<14)  /* closing tbc vars for error recovery */
+#define CIST_CLSSUP	(1<<15)  /* error suppressed by __close, still closing */
 
 
 /*

--- a/lundump.c
+++ b/lundump.c
@@ -264,8 +264,8 @@ static void loadFunction (LoadState *S, Proto *f, TString *psource) {
   f->numparams = loadByte(S);
   f->is_vararg = loadByte(S);
   f->maxstacksize = loadByte(S);
-  f->needclose = loadByte(S);
   loadCode(S, f);
+  luaF_setneedclose(f);
   loadConstants(S, f);
   loadUpvalues(S, f);
   loadProtos(S, f);

--- a/lundump.c
+++ b/lundump.c
@@ -264,6 +264,7 @@ static void loadFunction (LoadState *S, Proto *f, TString *psource) {
   f->numparams = loadByte(S);
   f->is_vararg = loadByte(S);
   f->maxstacksize = loadByte(S);
+  f->needclose = loadByte(S);
   loadCode(S, f);
   loadConstants(S, f);
   loadUpvalues(S, f);

--- a/lvm.c
+++ b/lvm.c
@@ -857,6 +857,11 @@ void luaV_finishOp (lua_State *L) {
       break;
     }
     case OP_CLOSE: {  /* yielded closing variables */
+      if (ci->callstatus & CIST_CLSERR) {
+        if (!(ci->callstatus & CIST_CLSSUP) && ttistrue(s2v(L->top.p - 1)))
+          ci->callstatus |= CIST_CLSSUP;
+        L->top.p--;  /* remove __close result */
+      }
       ci->u.l.savedpc--;  /* repeat instruction to close other vars. */
       break;
     }
@@ -1157,6 +1162,9 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   StkId base;
   const Instruction *pc;
   int trap;
+  struct lua_longjmp lj;
+  volatile int hastbcjmp = 0;
+  CallInfo * volatile tbcci = NULL;
 #if LUA_USE_JUMPTABLE
 #include "ljumptab.h"
 #endif
@@ -1169,6 +1177,84 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
   if (l_unlikely(trap))
     trap = luaG_tracecall(L);
   base = ci->func.p + 1;
+  if (cl->p->needclose) {
+    if (!hastbcjmp) {
+      lj.previous = L->errorJmp;
+      L->errorJmp = &lj;
+      hastbcjmp = 1;
+    }
+    lj.status = LUA_OK;
+    if (luai_setjmp(lj.b) != 0) {
+      /* recovery handler: error or yield caught */
+      int blkstatus = lj.status;
+      if (blkstatus == LUA_YIELD) {
+        L->errorJmp = lj.previous;
+        hastbcjmp = 0;
+        luaD_throw(L, LUA_YIELD);  /* forward yield */
+      }
+      /* check for a yieldable pcall between the error and our frame;
+         if found, defer to precover via the resume handler */
+      {
+        CallInfo *scan_ci;
+        for (scan_ci = L->ci; scan_ci != (CallInfo *)tbcci;
+             scan_ci = scan_ci->previous) {
+          if (scan_ci->callstatus & CIST_YPCALL) {
+            L->errorJmp = lj.previous;
+            hastbcjmp = 0;
+            luaD_throw(L, blkstatus);
+          }
+        }
+      }
+      ci = (CallInfo *)tbcci;
+      L->ci = ci;
+      cl = ci_func(ci);
+      base = ci->func.p + 1;
+      /* walk up frames to find one with tbc blocks */
+      while (L->tbclist.p < base) {
+        if (ci->callstatus & CIST_FRESH) {
+          L->errorJmp = lj.previous;
+          hastbcjmp = 0;
+          luaD_throw(L, blkstatus);  /* no tbc in our scope, re-throw */
+        }
+        ci = ci->previous;
+        L->ci = ci;
+        lua_assert(isLua(ci));
+        cl = ci_func(ci);
+        base = ci->func.p + 1;
+      }
+      tbcci = ci;
+      {
+        /* find OP_CLOSE covering the innermost tbc var */
+        int R = cast_int(L->tbclist.p - base);
+        const Instruction *scan = ci->u.l.savedpc;
+        const Instruction *codeend = cl->p->code + cl->p->sizecode;
+        while (scan < codeend) {
+          if (GET_OPCODE(*scan) == OP_CLOSE && GETARG_A(*scan) <= R)
+            break;
+          scan++;
+        }
+        if (scan >= codeend) {
+          /* tbc var is function-level, not block-level;
+             let pcall/resume handle it */
+          L->errorJmp = lj.previous;
+          hastbcjmp = 0;
+          luaD_throw(L, blkstatus);
+        }
+        ci->callstatus |= CIST_CLSERR;
+        setcistrecst(ci, blkstatus);
+        ci->u.l.savedpc = scan;
+      }
+      if (L->top.p < ci->top.p)
+        L->top.p = ci->top.p;
+      trap = 0;
+      goto returning;
+    }
+    tbcci = ci;
+  }
+  else if (hastbcjmp) {
+    L->errorJmp = lj.previous;
+    hastbcjmp = 0;
+  }
   /* main loop of interpreter */
   for (;;) {
     Instruction i;  /* instruction being executed */
@@ -1590,7 +1676,26 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_CLOSE) {
         StkId ra = RA(i);
-        Protect(luaF_closewithouterr(L, ra, LUA_OK, 1));
+        if (ci->callstatus & CIST_CLSERR) {
+          int suppressed = ci->callstatus & CIST_CLSSUP;
+          int status;
+          if (suppressed)
+            status = CLOSEKTOP;
+          else
+            status = getcistrecst(ci);
+          Protect(luaF_close(L, ra, &status, 1));
+          ci->callstatus &= ~(CIST_CLSERR | CIST_CLSSUP);
+          setcistrecst(ci, LUA_OK);
+          if (status == LUA_OK || suppressed) {
+            vmbreak;  /* suppressed: continue to escape pc */
+          }
+          else {
+            luaD_throw(L, status);
+          }
+        }
+        else {
+          Protect(luaF_closewithouterr(L, ra, LUA_OK, 1));
+        }
         vmbreak;
       }
       vmcase(OP_TBC) {
@@ -1780,8 +1885,11 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           }
         }
        ret:  /* return from a Lua function */
-        if (ci->callstatus & CIST_FRESH)
+        if (ci->callstatus & CIST_FRESH) {
+          if (hastbcjmp)
+            L->errorJmp = lj.previous;
           return;  /* end this frame */
+        }
         else {
           ci = ci->previous;
           goto returning;  /* continue running caller in this frame */

--- a/lvm.c
+++ b/lvm.c
@@ -1727,7 +1727,10 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           ci->u2.nres = n;  /* save number of returns */
           if (L->top.p < ci->top.p)
             L->top.p = ci->top.p;
+          L->savedret = savestack(L, ra);
+          L->nsavedret = n;
           luaF_close(L, base, CLOSEKTOP, 1, NULL);
+          L->savedret = 0;
           updatetrap(ci);
           updatestack(ci);
         }

--- a/lvm.c
+++ b/lvm.c
@@ -1590,7 +1590,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_CLOSE) {
         StkId ra = RA(i);
-        Protect(luaF_close(L, ra, LUA_OK, 1));
+        Protect(luaF_close(L, ra, LUA_OK, 1, NULL));
         vmbreak;
       }
       vmcase(OP_TBC) {
@@ -1727,7 +1727,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
           ci->u2.nres = n;  /* save number of returns */
           if (L->top.p < ci->top.p)
             L->top.p = ci->top.p;
-          luaF_close(L, base, CLOSEKTOP, 1);
+          luaF_close(L, base, CLOSEKTOP, 1, NULL);
           updatetrap(ci);
           updatestack(ci);
         }

--- a/lvm.c
+++ b/lvm.c
@@ -1590,7 +1590,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
       }
       vmcase(OP_CLOSE) {
         StkId ra = RA(i);
-        Protect(luaF_close(L, ra, LUA_OK, 1, NULL));
+        Protect(luaF_closewithouterr(L, ra, LUA_OK, 1));
         vmbreak;
       }
       vmcase(OP_TBC) {
@@ -1729,7 +1729,7 @@ void luaV_execute (lua_State *L, CallInfo *ci) {
             L->top.p = ci->top.p;
           L->savedret = savestack(L, ra);
           L->nsavedret = n;
-          luaF_close(L, base, CLOSEKTOP, 1, NULL);
+          luaF_closewithouterr(L, base, CLOSEKTOP, 1);
           L->savedret = 0;
           updatetrap(ci);
           updatestack(ci);

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -1050,6 +1050,70 @@ end
 
 
 do
+  -- yielding __close returns true: suppression across yield
+  local co = coroutine.wrap(function ()
+    return pcall(function ()
+      local x <close> = func2close(function (_, msg)
+        coroutine.yield("x")
+        return true   -- suppress the error
+      end)
+      error(42)
+    end)
+  end)
+
+  local a = co()
+  assert(a == "x")      -- yields from __close
+  local ok, msg = co()  -- resumes; __close returns true → suppressed
+  assert(ok == true and msg == nil)  -- pcall sees no error
+end
+
+
+do
+  -- yielding __close returns non-true: no suppression across yield
+  local co = coroutine.wrap(function ()
+    return pcall(function ()
+      local x <close> = func2close(function (_, msg)
+        coroutine.yield("x")
+        return 1   -- truthy but not true
+      end)
+      error(42)
+    end)
+  end)
+
+  local a = co()
+  assert(a == "x")
+  local ok, msg = co()
+  assert(ok == false and msg == 42)  -- error not suppressed
+end
+
+
+do
+  -- multiple <close> with yield: first suppresses, subsequent see nil
+  local seq = {}
+  local co = coroutine.wrap(function ()
+    return pcall(function ()
+      local a <close> = func2close(function (_, msg)
+        coroutine.yield("a")
+        seq[#seq + 1] = msg   -- should be nil (suppressed)
+      end)
+      local b <close> = func2close(function (_, msg)
+        coroutine.yield("b")
+        seq[#seq + 1] = msg   -- should be 99 (original error)
+        return true            -- suppress
+      end)
+      error(99)
+    end)
+  end)
+
+  assert(co() == "b")     -- b yields first (reverse order)
+  assert(co() == "a")     -- a yields
+  local ok = co()         -- a finishes
+  assert(ok == true)      -- suppressed
+  assert(seq[1] == 99 and seq[2] == nil)
+end
+
+
+do
   -- an error in a wrapped coroutine closes variables
   local x = false
   local y = false

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -875,6 +875,52 @@ do  -- __close returning true suppresses error
 end
 
 
+do  -- block-level error suppression (no pcall)
+  -- basic: error in block, __close suppresses, execution continues
+  local reached = false
+  do
+    local x <close> = func2close(function () return true end)
+    error("oops")
+  end
+  reached = true
+  assert(reached)
+
+  -- nested blocks: inner doesn't suppress, outer does
+  reached = false
+  do
+    local x <close> = func2close(function () return true end)
+    do
+      local y <close> = func2close(function () end)
+      error("nested")
+    end
+  end
+  reached = true
+  assert(reached)
+
+  -- pcall inside tbc block works normally
+  do
+    local x <close> = func2close(function () return true end)
+    local ok, msg = pcall(function () error("pcall-err") end)
+    assert(not ok and string.find(msg, "pcall%-err"))
+    error("block-err")
+  end
+
+  -- yielding __close with block-level suppression in coroutine
+  local co = coroutine.wrap(function ()
+    do
+      local x <close> = func2close(function ()
+        coroutine.yield("closing")
+        return true
+      end)
+      error("coro-err")
+    end
+    return "after-block"
+  end)
+  assert(co() == "closing")
+  assert(co() == "after-block")
+end
+
+
 print "to-be-closed variables in coroutines"
 
 do

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -808,6 +808,73 @@ do   -- '__close' vs. return hooks in Lua functions
 end
 
 
+do  -- __close returning true suppresses error
+  -- basic suppression: __close returns true, pcall sees no error
+  local closed = false
+  local ok = pcall(function ()
+    local x <close> = func2close(function () closed = true; return true end)
+    error("fail")
+  end)
+  assert(ok and closed)
+
+  -- only exact true suppresses; other truthy values do not
+  for _, v in ipairs({1, "yes", {}, 0}) do
+    local ok, msg = pcall(function ()
+      local x <close> = func2close(function () return v end)
+      error("fail")
+    end)
+    assert(not ok and string.find(msg, "fail"))
+  end
+
+  -- multiple <close> vars: first suppresses, subsequent see nil error
+  local seq = {}
+  local ok = pcall(function ()
+    local a <close> = func2close(function (_, msg)
+      seq[#seq + 1] = msg    -- should be nil (suppressed)
+    end)
+    local b <close> = func2close(function (_, msg)
+      seq[#seq + 1] = msg    -- should be "fail" (original error)
+      return true             -- suppress
+    end)
+    error("fail")
+  end)
+  assert(ok)
+  assert(string.find(seq[1], "fail") and seq[2] == nil)
+
+  -- suppression produces LUA_OK: pcall returns true (no error values)
+  local r1, r2 = pcall(function ()
+    local x <close> = func2close(function () return true end)
+    error("oops")
+  end)
+  assert(r1 == true and r2 == nil)
+
+  -- nested pcall: suppression in inner does not affect outer
+  local inner_ok, outer_ok
+  outer_ok = pcall(function ()
+    local x <close> = func2close(function () end)   -- no suppression
+    inner_ok = pcall(function ()
+      local y <close> = func2close(function () return true end)
+      error("inner")
+    end)
+    assert(inner_ok)
+    error("outer")
+  end)
+  assert(inner_ok and not outer_ok)
+
+  -- __close error during suppressed close: new error takes precedence
+  local ok, msg = pcall(function ()
+    local a <close> = func2close(function ()
+      error("new-error")
+    end)
+    local b <close> = func2close(function ()
+      return true   -- suppress original
+    end)
+    error("original")
+  end)
+  assert(not ok and string.find(msg, "new%-error"))
+end
+
+
 print "to-be-closed variables in coroutines"
 
 do

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -861,6 +861,14 @@ do  -- __close returning true suppresses error
   end)
   assert(inner_ok and not outer_ok)
 
+  -- return values preserved when error-in-close is suppressed
+  local r1, r2, r3 = pcall(function ()
+    local b <close> = func2close(function () return true end)  -- suppress
+    local a <close> = func2close(function () error("fail") end)  -- error
+    return 10, 20
+  end)
+  assert(r1 == true and r2 == 10 and r3 == 20)
+
   -- __close error during suppressed close: new error takes precedence
   local ok, msg = pcall(function ()
     local a <close> = func2close(function ()
@@ -1113,7 +1121,7 @@ do
 end
 
 do
-  -- XXX yielding inside closing metamethods after an error, with error suppression
+  -- yielding inside closing metamethods after an error, with error suppression
 
   local co = coroutine.wrap(function ()
 
@@ -1162,8 +1170,6 @@ do
   a, b = co()
   assert(a == "z" and b == nil)    -- yields inside 'z'; Ok
   local a, b, c = co()
-  -- FIXME: return value of foo() is being lost, even though error is suppressed
-  -- YYY
   assert(a and b == 10 and c == 20)   -- returns from 'pcall(foo, 1)'
 
   local a, b = co()    -- third foo: error in function body

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -1112,6 +1112,71 @@ do
   assert(seq[1] == 99 and seq[2] == nil)
 end
 
+do
+  -- XXX yielding inside closing metamethods after an error, with error suppression
+
+  local co = coroutine.wrap(function ()
+
+    local function foo (err)
+
+      local z <close> = func2close(function(_, msg)
+        assert(msg == nil or msg == err + 20)
+        coroutine.yield("z")
+        return true
+      end)
+
+      local y <close> = func2close(function(_, msg)
+        -- still gets the original error (if any)
+        assert(msg == err or (msg == nil and err == 1))
+        coroutine.yield("y")
+        if err then error(err + 20) end   -- creates or changes the error
+      end)
+
+      local x <close> = func2close(function(_, msg)
+        assert(msg == err or (msg == nil and err == 1))
+        coroutine.yield("x")
+        return 100, 200
+      end)
+
+      if err == 10 then error(err) else return 10, 20 end
+    end
+
+    coroutine.yield(pcall(foo, nil))  -- no error
+    coroutine.yield(pcall(foo, 1))    -- error in __close
+    return pcall(foo, 10)     -- 'foo' will raise an error
+  end)
+
+  local a, b = co()   -- first foo: no error
+  assert(a == "x" and b == nil)    -- yields inside 'x'; Ok
+  a, b = co()
+  assert(a == "y" and b == nil)    -- yields inside 'y'; Ok
+  a, b = co()
+  assert(a == "z" and b == nil)    -- yields inside 'z'; Ok
+  local a, b, c = co()
+  assert(a and b == 10 and c == 20)   -- returns from 'pcall(foo, nil)'
+
+  local a, b = co()   -- second foo: error in __close
+  assert(a == "x" and b == nil)    -- yields inside 'x'; Ok
+  a, b = co()
+  assert(a == "y" and b == nil)    -- yields inside 'y'; Ok
+  a, b = co()
+  assert(a == "z" and b == nil)    -- yields inside 'z'; Ok
+  local a, b, c = co()
+  -- FIXME: return value of foo() is being lost, even though error is suppressed
+  -- YYY
+  assert(a and b == 10 and c == 20)   -- returns from 'pcall(foo, 1)'
+
+  local a, b = co()    -- third foo: error in function body
+  assert(a == "x" and b == nil)    -- yields inside 'x'; Ok
+  a, b = co()
+  assert(a == "y" and b == nil)    -- yields inside 'y'; Ok
+  a, b = co()
+  assert(a == "z" and b == nil)    -- yields inside 'z'; Ok
+  local a, b = co()
+  assert(a and b == nil)    -- returns from 'pcall(foo, 10)'
+
+end
+
 
 do
   -- an error in a wrapped coroutine closes variables

--- a/testes/locals.lua
+++ b/testes/locals.lua
@@ -809,13 +809,12 @@ end
 
 
 do  -- __close returning true suppresses error
-  -- basic suppression: __close returns true, pcall sees no error
-  local closed = false
-  local ok = pcall(function ()
-    local x <close> = func2close(function () closed = true; return true end)
+  -- basic suppression: pcall returns only true (no error values)
+  local r1, r2 = pcall(function ()
+    local x <close> = func2close(function () return true end)
     error("fail")
   end)
-  assert(ok and closed)
+  assert(r1 == true and r2 == nil)
 
   -- only exact true suppresses; other truthy values do not
   for _, v in ipairs({1, "yes", {}, 0}) do
@@ -840,13 +839,6 @@ do  -- __close returning true suppresses error
   end)
   assert(ok)
   assert(string.find(seq[1], "fail") and seq[2] == nil)
-
-  -- suppression produces LUA_OK: pcall returns true (no error values)
-  local r1, r2 = pcall(function ()
-    local x <close> = func2close(function () return true end)
-    error("oops")
-  end)
-  assert(r1 == true and r2 == nil)
 
   -- nested pcall: suppression in inner does not affect outer
   local inner_ok, outer_ok
@@ -1056,69 +1048,6 @@ do
 
 end
 
-
-do
-  -- yielding __close returns true: suppression across yield
-  local co = coroutine.wrap(function ()
-    return pcall(function ()
-      local x <close> = func2close(function (_, msg)
-        coroutine.yield("x")
-        return true   -- suppress the error
-      end)
-      error(42)
-    end)
-  end)
-
-  local a = co()
-  assert(a == "x")      -- yields from __close
-  local ok, msg = co()  -- resumes; __close returns true → suppressed
-  assert(ok == true and msg == nil)  -- pcall sees no error
-end
-
-
-do
-  -- yielding __close returns non-true: no suppression across yield
-  local co = coroutine.wrap(function ()
-    return pcall(function ()
-      local x <close> = func2close(function (_, msg)
-        coroutine.yield("x")
-        return 1   -- truthy but not true
-      end)
-      error(42)
-    end)
-  end)
-
-  local a = co()
-  assert(a == "x")
-  local ok, msg = co()
-  assert(ok == false and msg == 42)  -- error not suppressed
-end
-
-
-do
-  -- multiple <close> with yield: first suppresses, subsequent see nil
-  local seq = {}
-  local co = coroutine.wrap(function ()
-    return pcall(function ()
-      local a <close> = func2close(function (_, msg)
-        coroutine.yield("a")
-        seq[#seq + 1] = msg   -- should be nil (suppressed)
-      end)
-      local b <close> = func2close(function (_, msg)
-        coroutine.yield("b")
-        seq[#seq + 1] = msg   -- should be 99 (original error)
-        return true            -- suppress
-      end)
-      error(99)
-    end)
-  end)
-
-  assert(co() == "b")     -- b yields first (reverse order)
-  assert(co() == "a")     -- a yields
-  local ok = co()         -- a finishes
-  assert(ok == true)      -- suppressed
-  assert(seq[1] == 99 and seq[2] == nil)
-end
 
 do
   -- yielding inside closing metamethods after an error, with error suppression


### PR DESCRIPTION
Add support for to-be-closed variable `__close` metamethods to suppress in-flight errors by returning `true`, similar to the `__exit__` protocol of Python's context managers.

Synopsis:
```python
do
  local x <close> = setmetatable({}, {
    __close = function(self, err)
      print('__close()')
      return true
    end
  })

  error('oops')
  print('not reached')
end

print('goodbye')
```

expected output:
```
__close()
goodbye
```

## Behavior

- a `__close` method returning exact boolean `true` suppresses the current error — execution continues as if no error occurred. Only exact `true` suppresses; other truthy values (1, "yes", {}) do not.
- after suppression, subsequent `__close` methods in the same scope see `nil` as the error argument
- Works at two levels:
  - **pcall boundary**: `pcall` returns `true` (plus original return values if the error occurred during the return-close phase)
  - **block level** (no pcall needed): execution continues after the block's `end`
- yielding `__close` methods are fully supported in both cases (coroutine yield/resume during error recovery preserves suppression state)

## Implementation summary

**suppression mechanism** (`lfunc.c`): `callclosemethod()` now requests 1 result and checks for `ttistrue()`. `luaF_close()` takes `int *status` (in-out) so callers can observe suppression. Added `luaF_closewithouterr()` convenience wrapper for non-error call sites.

**pcall path** (`ldo.c`): `finishpcallk()` uses new `CIST_CLSERR`/`CIST_CLSSUP` CI flags to track suppression state across yield/resume cycles. `luaD_pcall()` saves/restores return values via a heap buffer when suppression occurs during `OP_RETURN`, so that `pcall` can return the original values after the error is suppressed.  This is implemented with new `lua_State` fields (`retbuf`, `savedret`, `nsavedret`, `nretbuf`).  The buffer is GC-visible via `traversethread`, and freed on thread cleanup.

**block-level path** (`lvm.c`): `luaV_execute()` installs a `setjmp` recovery point for functions with tbc variables, gated by `Proto.needclose`. On error, the recovery handler scans forward from `savedpc` to locate the covering `OP_CLOSE`, then redirects the VM to re-execute it in an error-recovery mode, reusing the existing yield-during-close machinery. Multi-block and nested recovery is handled by re-throwing to the outer `setjmp` when inner blocks don't suppress. `needclose` is derived at compile and load time by scanning bytecode for co-occurring `OP_TBC`/`OP_TFORPREP` and `OP_CLOSE` instructions.  These choices maintain strict binary compatibility with stock Lua 5.4 at the cost of a per-function bytecode scan on load and the forward `OP_CLOSE` scan on each error recovery.

## Tests

Comprehensive tests in `testes/locals.lua` covering: basic suppression, multiple `<close>` vars, nested pcall, return value preservation, error-during-suppressed-close, block-level suppression (basic, nested blocks, pcall interaction), and yielding `__close` with suppression in coroutines.
